### PR TITLE
Fix non-terminating loop in DuplicateContainers::exists

### DIFF
--- a/include/vlog/ml/ml.h
+++ b/include/vlog/ml/ml.h
@@ -1,6 +1,8 @@
 #ifndef _ML_H
 #define _ML_H
 
+#include <cmath>
+
 #include <vlog/concepts.h>
 #include <kognac/progargs.h>
 

--- a/src/vlog/forward/joinprocessor.cpp
+++ b/src/vlog/forward/joinprocessor.cpp
@@ -2092,7 +2092,7 @@ bool DuplicateContainers::exists(const Term_t *v) {
         }
     } else {
         if (nfields == 1) {
-            uint8_t idxTable = 0;
+            size_t idxTable = 0;
             size_t emptyTables = 0;
             while (idxTable < ntables) {
                 if (tables[idxTable] != NULL) {
@@ -2115,7 +2115,7 @@ bool DuplicateContainers::exists(const Term_t *v) {
             }
             empty = emptyTables == ntables;
         } else {
-            uint8_t idxTable = 0;
+            size_t idxTable = 0;
             size_t emptyTables = 0;
             while (idxTable < ntables) {
                 if (tables[idxTable] != NULL) {


### PR DESCRIPTION
Fix an integer overflow that will leave vlog in a non-terminating loop: certain programs such as the one in #10 or the program below (which, contrary to #10, should terminate within reasonable amounts of both time and memory), e.g., will have `ntables >= 256`, but `idxTable` is a `uint8_t`, so `idxTable` will overflow from 255 to 0, and the loop will never terminate.

```
first(X) :- frst(X)
last(X) :- lst(X)
start(X) :- strt(X)
stop(X) :- stp(X)
next(X,Y) :- nxt(X,Y)

notLast(X) :- next(X,Y),last(Y)
notLast(X) :- next(X,Y),notLast(Y)
cont(X) :- next(X,Y),stop(Y)
cont(X) :- next(X,Y),cont(Y)

level(X,L) :- frst(X),strt(L)
level(Y,L) :- next(X,Y),level(X,L)

stage(X,L,S) :- level(X,L),frst(S)
stage(Y,L,S) :- next(X,Y),stage(X,L,S)
stage(Y,L,T) :- succ0(X,Y),stage(X,L,S),next(S,T)

succ0(X,Y) :- stage(X,L,S),nxt(S,T),notLast(T),cont(M)

first(Y) :- succ0(X,Y),first(X)
succ1(X,Z),next(Y,Z) :- succ0(X,Y)
next(X,Y) :- next(U,V),succ1(U,X),succ0(V,Y)
last(Y) :- last(X),succ1(X,Y)

succ0(X,Y),level(Y,M) :- stage(X,L,S),nxt(L,M),nxt(S,T),last(T)
```

edb.conf:
```
EDB0_predname=frst                                                                                                                          
EDB0_type=INMEMORY
EDB0_param0=.
EDB0_param1=first
EDB1_predname=lst
EDB1_type=INMEMORY
EDB1_param0=.
EDB1_param1=last
EDB2_predname=strt
EDB2_type=INMEMORY
EDB2_param0=.
EDB2_param1=start
EDB3_predname=stp
EDB3_type=INMEMORY
EDB3_param0=.
EDB3_param1=stop
EDB4_predname=nxt
EDB4_type=INMEMORY
EDB4_param0=.
EDB4_param1=next
```

first.csv:
```
c1
```

last.csv:
```
c5
```

start.csv:
```
d1
```

stop.csv:
```
d2
```

next.csv:
```
c1,c2
c2,c3
c3,c4
c4,c5
d1,d2
d2,d3
```