### PR TITLE
add user-agent to request for sparql endpoints

### DIFF
--- a/src/vlog/sparql/sparqltable.cpp
+++ b/src/vlog/sparql/sparqltable.cpp
@@ -187,6 +187,7 @@ json SparqlTable::launchQuery(std::string sparqlQuery) {
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, &rheaders);
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/sparql-results+json");
+    headers = curl_slist_append(headers, "User-Agent: VLog-v1.2.1");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
     CURLcode resp = curl_easy_perform(curl);


### PR DESCRIPTION
Wikidata SPARQL endpoint is answering "403 Forbidden" if the request's header does not define an user-agent.

This pull request defines an user-agent in the request's header that VLog executes when it tries to retrieve data from a SPARQL endpoint.

I just went ahead and set "VLog-v1.2.1" as user-agent, but you should decide a name.