### PR TITLE
Fixed bug on determining column dependency for ex variables.

### DIFF
--- a/null.d
+++ b/null.d
@@ -1,0 +1,1 @@
+null.o: /dev/null /usr/include/stdc-predef.h

--- a/null.d
+++ b/null.d
@@ -1,1 +1,0 @@
-null.o: /dev/null /usr/include/stdc-predef.h

--- a/src/vlog/forward/extresultjoinproc.cpp
+++ b/src/vlog/forward/extresultjoinproc.cpp
@@ -688,18 +688,23 @@ void ExistentialRuleProcessor::addColumns(const int blockid,
                     //Now that the columns are sorted, I no longer care
                     //about the indices
                     std::vector<std::shared_ptr<Column>> depc;
+                    std::vector<Var_t> varIds;
                     //A column may be used more than once in the head. Filter duplicates out.
                     //Otherwise, an assert goes off in getNewOrExistingIDs --Ceriel
+                    //The duplicates must be checked by variable, and not by column. There can be
+                    //two different head variables over the same column, but in this case they must be treated as different --Marco
                     for(auto &el : depc_t) {
                         bool present = false;
-                        for (auto &l : depc) {
-                            if (el.second == l) {
+                        auto varId = literal.getTermAtPos(el.first).getId();
+                        for (auto &l : varIds) {
+                            if ( varId == l) {
                                 present = true;
                                 break;
                             }
                         }
                         if (! present) {
                             depc.push_back(el.second);
+                            varIds.push_back(varId);
                         }
                     }
                     auto extcolumn = chaseMgmt->getNewOrExistingIDs(


### PR DESCRIPTION
Hi. We are using vlog for a paper we are writing together with my collegues, and I think I have found a bug in how vlog removes duplicate columns as dependencies for ex variables. The issue is that the current code keeps each column from the dependency list once. However, what it should be checked is not column duplicates, but frontier variable duplicates. Indeed, there are cases, where two head positions host the same column, but  by means of different variables. In this case, the column must remain repeated in the dependency list, otherwise an assert in getNewOrExistingIDs gets triggered.
To reproduce the issues, it is enough to feed vlog the following set of rule and run, e.g. the MFA check: vlog cycles --rules program.txt

program.txt:
p1(X1,X2,X3) :- p2(X1,X2,X4)
p2(X1,X1,X2) :- p3(X1)

here, in the first rule, the first two head positions host the same column coming from the second rule, but the two occurrences appear because of different variables. My fix now keeps those two occurrences in the depc vector.

Please let me know in case I misunderstood something about the code, and whether this is a valid fix.

Marco