### PR TITLE
Store IDB predicates only

### DIFF
--- a/src/vlog/forward/seminaiver.cpp
+++ b/src/vlog/forward/seminaiver.cpp
@@ -692,9 +692,11 @@ void SemiNaiver::storeOnFiles(std::string path, const bool decompress,
 
     //I create a new file for every idb predicate
     for (PredId_t i = 0; i < program->getNPredicates(); ++i) {
-        FCTable *table = predicatesTables[i];
-        if (table != NULL && !table->isEmpty()) {
-            storeOnFile(path + "/" + generateFileName(program->getPredicateName(i)), i, decompress, minLevel, csv);
+        if (program->isPredicateIDB(i)) {
+            FCTable *table = predicatesTables[i];
+            if (table != NULL && !table->isEmpty()) {
+                storeOnFile(path + "/" + generateFileName(program->getPredicateName(i)), i, decompress, minLevel, csv);
+            }
         }
     }
 }


### PR DESCRIPTION
Regardless code comments, VLog save both EDB and IDB predicates's extensions after materialization.

In this pull request we check first if the predicate is actually an IDB predicate, and only then we save its extension.

